### PR TITLE
Add inheritsHooksFrom, update README (Fix #7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,9 +135,15 @@ Template.foo.events({
 
 Template.foo2.inheritsHelpersFrom("foo");
 Template.foo2.inheritsEventsFrom("foo");
+
+Template.foo.created = function () {
+  console.log('foo');
+};
+
+Template.foo2.inheritsHooksFrom("foo");
 ```
 
-In this example, both templates are rendered. Both use the `bar` helper defined on "foo" to resolve `{{bar}}`. Both fire the click event defined on "foo".
+In this example, both templates are rendered. Both use the `bar` helper defined on "foo" to resolve `{{bar}}`. Both fire the click event defined on "foo". Additionally, the "foo2" template will inherit the `foo.created` callback and log 'foo' to the console upon creation.
 
 ## copyAs(newTemplateName)
 

--- a/template-extension.js
+++ b/template-extension.js
@@ -28,10 +28,6 @@ Meteor.startup(function () {
         runGlobalHooks(type, this, arguments);
         // call all defined hooks for this template instance
         runTemplateHooks(type, this, arguments);
-        // call the existing callback if there was one
-        if (typeof orig === "function") {
-          orig.apply(this, arguments);
-        }
       };
     }
 

--- a/template-extension.js
+++ b/template-extension.js
@@ -138,6 +138,30 @@ Template.prototype.inheritsEventsFrom = function (otherTemplateName) {
   Template[name].__eventMaps = otherTemplate.__eventMaps;
 };
 
+Template.prototype.inheritsHooksFrom = function (otherTemplateName) {
+  var self = this;
+
+  var otherTemplate = Template[otherTemplateName];
+  if (!otherTemplate) {
+    console.warn("Can't inherit hooks from template " + otherTemplateName + " because it hasn't been defined yet.");
+    return;
+  }
+
+  var name = parseName(self.viewName);
+  
+  // For each hookType check if there are existing templateHooks for otherTemplate
+  _.each(hookTypes, function (type) {
+    var hooks = templateHooks[otherTemplateName][type];
+    // For each existing hook for otherTemplate
+    _.each(hooks, function (hook) {
+      // Initialize the target template's templateHooks array
+      templateHooks[name][type] = templateHooks[name][type] || [];
+      // Add hook
+      templateHooks[name][type].push(hook);
+    });
+  });
+};
+
 Template.prototype.copyAs = function (newTemplateName) {
   var self = this;
 
@@ -147,7 +171,8 @@ Template.prototype.copyAs = function (newTemplateName) {
 
     var name = parseName(self.viewName);
     newTemplate.inheritsHelpersFrom(name);
-    newTemplate.inheritsEventsFrom(name);  
+    newTemplate.inheritsEventsFrom(name);
+    newTemplate.inheritsHooksFrom(name);
   };
 
   //Check if newTemplateName is an array

--- a/template-extension.js
+++ b/template-extension.js
@@ -179,7 +179,7 @@ Template.prototype.inheritsHooksFrom = function (otherTemplateName) {
 
 Template.prototype.copyAs = function (newTemplateName) {
   var self = this;
-
+  
   var createNewTemplate = function (templateName) {
     var newTemplate =
     Template[templateName] = new Template('Template.' + templateName, self.renderFunction);
@@ -209,6 +209,7 @@ Template.prototype.copyAs = function (newTemplateName) {
 // that the field exists somewhere.
 Blaze.TemplateInstance.prototype.get = function (fieldName) {
   var template = this;
+
   while (template) {
     if (fieldName in template) {
       return template[fieldName];
@@ -306,7 +307,7 @@ function runGlobalHooks(type, template, args) {
 }
 
 function runTemplateHooks(type, template, args) {
-  var i, name = parseName(template.viewName), h = templateHooks[type][name];
+  var i, name = parseName(template.viewName) || parseName(template.view.name), h = templateHooks[type][name];
   var hl = h ? h.length : 0;
   for (i = 0; i < hl; i++) {
     h[i].apply(template, args);


### PR DESCRIPTION
Now there is an `inheritsHooksFrom` method, we inherit hooks by default when invoking `copyAs`. Readme has been updated with an example.