### PR TITLE
Return newly created template from copyAs (Fix #9)

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,10 @@ Template.bar.helpers({
 
 In this example, we defined "foo" and "bar" templates that get their HTML markup, events, and helpers from a base template, `abstract_foo`. We then override the `images` helper for "foo" and "bar" to provide template-specific images provided by different Meteor methods. Template.template.copyAs can accept either single template name (in string form), or an array of template names as shown in the above example.
 
+If copyAs is invoked with a string, it returns the newly created template.
+
+If copyAs is invoked with an array, it returns an array of newly created templates.
+
 ## template.parent(numLevels, includeBlockHelpers)
 
 On template instances you can now use `parent(numLevels)` method to access a parent template instance.

--- a/template-extension.js
+++ b/template-extension.js
@@ -204,7 +204,7 @@ Template.prototype.inheritsHooksFrom = function (otherTemplateName) {
 };
 
 Template.prototype.copyAs = function (newTemplateName) {
-  var self = this;
+  var self = this, result = [];
   
   var createNewTemplate = function (templateName) {
     var newTemplate =
@@ -214,15 +214,22 @@ Template.prototype.copyAs = function (newTemplateName) {
     newTemplate.inheritsHelpersFrom(name);
     newTemplate.inheritsEventsFrom(name);
     newTemplate.inheritsHooksFrom(name);
+
+    return newTemplate;
   };
 
   //Check if newTemplateName is an array
   if (_.isArray(newTemplateName)) {
     _.each(newTemplateName, function (name) {
-      createNewTemplate(name);
+      var template = createNewTemplate(name);
+      //Push newly created template into array that we'll return
+      result.push(template);
     });
+    return result;
   } else { //newTemplateName is a string
-    createNewTemplate(newTemplateName);
+    var template = createNewTemplate(newTemplateName);
+    //return newly created array
+    return template;
   }
 };
 

--- a/template-extension.js
+++ b/template-extension.js
@@ -182,13 +182,13 @@ Template.prototype.inheritsHooksFrom = function (otherTemplateName) {
     }
     // For each hookType check if there are existing templateHooks for templateName
     _.each(hookTypes, function (type) {
-      var hooks = templateHooks[templateName][type];
+      var hooks = templateHooks[type][templateName];
       // For each existing hook for templateName
       _.each(hooks, function (hook) {
         // Initialize the target template's templateHooks array
-        templateHooks[name][type] = templateHooks[name][type] || [];
+        templateHooks[type][name] = templateHooks[type][name] || [];
         // Add hook
-        templateHooks[name][type].push(hook);
+        templateHooks[type][name].push(hook);
       });
     });
   };

--- a/tests.html
+++ b/tests.html
@@ -28,6 +28,9 @@
 <template name="testTemplate8">
 </template>
 
+<template name="testTemplate9">
+</template>
+
 <template name="noop">
   {{> Template.contentBlock}}
 </template>

--- a/tests.html
+++ b/tests.html
@@ -10,6 +10,24 @@
   {{testInstanceGet}}{{testInstanceParent}}{{testData}}
 </template>
 
+<template name="testTemplate3">
+</template>
+
+<template name="testTemplate4">
+</template>
+
+<template name="testTemplate5">
+</template>
+
+<template name="testTemplate6">
+</template>
+
+<template name="testTemplate7">
+</template>
+
+<template name="testTemplate8">
+</template>
+
 <template name="noop">
   {{> Template.contentBlock}}
 </template>

--- a/tests.js
+++ b/tests.js
@@ -162,9 +162,9 @@ Tinytest.add('template-extension - inheritsHooksFrom', function (test) {
 });
 
 Tinytest.add('template-extension - inheritsHooksFrom array', function (test) {
-  Template.testTemplate7.inheritsHooksFrom(['testTemplate', 'testTemplate8']);
-  Template.testTemplate7.created();
-  Template.testTemplate7.rendered();
-  test.equal(Template.testTemplate7._testTemplateField, 42);
-  test.equal(Template.testTemplate7._testTemplateField4, 14);
+  Template.testTemplate9.inheritsHooksFrom(['testTemplate', 'testTemplate8']);
+  Template.testTemplate9.created();
+  Template.testTemplate9.rendered();
+  test.equal(Template.testTemplate9._testTemplateField, 42);
+  test.equal(Template.testTemplate9._testTemplateField4, 14);
 });

--- a/tests.js
+++ b/tests.js
@@ -168,3 +168,15 @@ Tinytest.add('template-extension - inheritsHooksFrom array', function (test) {
   test.equal(Template.testTemplate9._testTemplateField, 42);
   test.equal(Template.testTemplate9._testTemplateField4, 14);
 });
+
+Tinytest.add('template-extension - copyAs returns newly created template', function (test) {
+  var result = Template.testTemplate.copyAs('testTemplate3');
+  test.instanceOf(result, Blaze.Template);
+});
+
+Tinytest.add('template-extension - copyAs returns newly created template array', function (test) {
+  var result = Template.testTemplate.copyAs(['testTemplate3', 'testTemplate4']);
+  test.instanceOf(result, Array);
+  test.instanceOf(result[0], Blaze.Template);
+  test.instanceOf(result[1], Blaze.Template);
+});

--- a/tests.js
+++ b/tests.js
@@ -54,6 +54,24 @@ Template.testTemplate2.helpers({
   }
 });
 
+Template.testTemplate3.events({
+  'click #button': function () {
+    return true;
+  }
+});
+
+Template.testTemplate4.events({
+  'mousemove .current': function () {
+    return true;
+  }
+});
+
+Template.testTemplate8.hooks({
+  rendered: function () {
+    this._testTemplateField4 = 14;
+  }
+});
+
 Tinytest.add('template-extension - get', function (test) {
   testingInstanceGet = true;
   try {
@@ -113,4 +131,40 @@ Tinytest.add('template-extension - parentData', function (test) {
   finally {
     testingData = false;
   }
+});
+
+Tinytest.add('template-extension - inheritsHelpersFrom', function (test) {
+  Template.testTemplate3.inheritsHelpersFrom('testTemplate2');
+  test.equal(Template.testTemplate2.__helpers[' testInstanceGet'], Template.testTemplate3.__helpers[' testInstanceGet']);
+});
+
+Tinytest.add('template-extension - inheritsHelpersFrom array', function (test) {
+  Template.testTemplate4.inheritsHelpersFrom(['testTemplate1', 'testTemplate2']);
+  test.equal(Template.testTemplate2.__helpers[' testInstanceGet'], Template.testTemplate4.__helpers[' testInstanceGet']);
+  test.equal(Template.testTemplate1.__helpers[' data'], Template.testTemplate4.__helpers[' data']);
+});
+
+Tinytest.add('template-extension - inheritsEventsFrom', function (test) {
+  Template.testTemplate5.inheritsEventsFrom('testTemplate3');
+  test.equal(Template.testTemplate3.__eventMaps, Template.testTemplate5.__eventMaps);
+});
+
+Tinytest.add('template-extension - inheritsEventsFrom array', function (test) {
+  Template.testTemplate6.inheritsEventsFrom(['testTemplate3', 'testTemplate4']);
+  test.equal(Template.testTemplate3.__eventMaps[0], Template.testTemplate6.__eventMaps[0]);
+  test.equal(Template.testTemplate4.__eventMaps[0], Template.testTemplate6.__eventMaps[1]);
+});
+
+Tinytest.add('template-extension - inheritsHooksFrom', function (test) {
+  Template.testTemplate7.inheritsHooksFrom('testTemplate');
+  Template.testTemplate7.created();
+  test.equal(Template.testTemplate7._testTemplateField, 42);
+});
+
+Tinytest.add('template-extension - inheritsHooksFrom array', function (test) {
+  Template.testTemplate7.inheritsHooksFrom(['testTemplate', 'testTemplate8']);
+  Template.testTemplate7.created();
+  Template.testTemplate7.rendered();
+  test.equal(Template.testTemplate7._testTemplateField, 42);
+  test.equal(Template.testTemplate7._testTemplateField4, 14);
 });


### PR DESCRIPTION
If copyAs is invoked with a string, it returns the newly created template.

If copyAs is invoked with an array, it returns an array of the newly created templates.