### PR TITLE
Adding underscore to package dependencies

### DIFF
--- a/package.js
+++ b/package.js
@@ -11,6 +11,7 @@ Package.onUse(function(api) {
     'templating',
     'blaze',
     'jquery',
+    'underscore',
     'tracker'
   ], 'client');
 


### PR DESCRIPTION
Underscore is required as a dependency because otherwise it won't be available in some cases and cause errors which can prevent the page from rendering.