### PR TITLE
Use the offical API for adding inherited helpers to the template

### DIFF
--- a/template-extension.js
+++ b/template-extension.js
@@ -118,7 +118,14 @@ Template.prototype.inheritsHelpersFrom = function (otherTemplateName) {
     }
 
     if (otherTemplate.__helpers) {
-      thisTemplate.__helpers = $.extend({}, thisTemplate.__helpers, otherTemplate.__helpers);
+      var inherited_helpers = {};
+
+      _.each(otherTemplate.__helpers, function (helper, name) {
+        if (name.charAt(0) === " ")
+          inherited_helpers[name.slice(1)] = helper;
+      });
+
+      thisTemplate.helpers(inherited_helpers);
     }
 
     else {


### PR DESCRIPTION
I'm creating a package that wraps the two core methods for setting and retrieving helpers on a template – `Template.prototype.helpers` and `Blaze._getTemplateHelper` (even if the latter isn't official) – in order to make the two methods reactive, like ReactiveDict.

This way, a helper that is added after the template is rendered (or while it is being rendered), will still become active. This is discussed [here](https://github.com/meteor/meteor/issues/5194).

The problem with wrapping the two methods is if *someone* writes directly to the `__helpers` map, and I think your package is by far the most popular package that does this.

Please merge this tiny pull request to support the pattern above. Thanks :)