### PR TITLE
Allow the first argument of parent to be a selector function.

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,12 @@ On template instances you can now use `parent(numLevels)` method to access a par
 By default block helper template instances are skipped, but if `includeBlockHelpers` is set to true,
 they are not.
 
+## templateInstance.parent(selector, includeBlockHelpers)
+
+You can also call `templateInstance.parent` with function as first argument. The function, known as selector, will be
+passed the current template being traversed. If it returns true, we return the template that is currently being traversed,
+otherwise, we traverse further up. We traverse up until there are no more templates, in which case, we return null.
+
 ## templateInstance.get(fieldName)
 
 To not have to hard-code the number of levels when accessing parent template instances you can use

--- a/lib/template-instance-parent.js
+++ b/lib/template-instance-parent.js
@@ -1,14 +1,19 @@
 /**
- * @param selector A function that is given a template as we traverse up the template true. It is passed the template
+ * @param selector Can be a height or a function.
+ *        Height. The number of levels beyond the current template instance to look.
+ *        Defaults to 0.
+ *
+ *        Function that is given a template as we traverse up the template true. It is passed the template
  *        currently being traversed. If it returns true, then that template is returned, otherwise next is used. This
- *        is done till we hit a element with null as parent.
+ *        is done till we hit a template with no parent, in which case null is returned.
  * @param includeBlockHelpers True to include block helpers.
  * @returns {*}
  */
 Blaze.TemplateInstance.prototype.parent = function parent(selector, includeBlockHelpers) {
   let template = null;
   if (_.isFinite(selector) || !selector) {
-    var height = selector;
+    // If height is null or undefined, we default to 1, the first parent.
+    var height = !selector ? 1 : selector;
     template = parentByHeight.call(this, height, includeBlockHelpers);
   } else if (_.isFunction(selector)) {
     template = parentByHeight.call(this, Number.MAX_VALUE, includeBlockHelpers, selector);
@@ -24,9 +29,6 @@ Blaze.TemplateInstance.prototype.parent = function parent(selector, includeBlock
 // are skipped, but if "includeBlockHelpers" is set to true, they are not.
 // See https://github.com/meteor/meteor/issues/3071
 function parentByHeight(height, includeBlockHelpers, selector) {
-  // If height is null or undefined, we default to 1, the first parent.
-  if (height == null) height = 1;
-
   var i = 0;
   var template = this;
   while (i < height && template) {

--- a/lib/template-instance-parent.js
+++ b/lib/template-instance-parent.js
@@ -1,8 +1,29 @@
+/**
+ * @param selector A function that is given a template as we traverse up the template true. It is passed the template
+ *        currently being traversed. If it returns true, then that template is returned, otherwise next is used. This
+ *        is done till we hit a element with null as parent.
+ * @param includeBlockHelpers True to include block helpers.
+ * @returns {*}
+ */
+Blaze.TemplateInstance.prototype.parent = function parent(selector, includeBlockHelpers) {
+  let template = null;
+  if (_.isFinite(selector) || !selector) {
+    var height = selector;
+    template = parentByHeight.call(this, height, includeBlockHelpers);
+  } else if (_.isFunction(selector)) {
+    template = parentByHeight.call(this, Number.MAX_VALUE, includeBlockHelpers, selector);
+  } else {
+    throw "template:children Template.parent() is given an invalid selector type."
+  }
+
+  return template;
+};
+
 // Access parent template instance. "height" is the number of levels beyond the
 // current template instance to look. By default block helper template instances
 // are skipped, but if "includeBlockHelpers" is set to true, they are not.
 // See https://github.com/meteor/meteor/issues/3071
-Blaze.TemplateInstance.prototype.parent = function parent(height, includeBlockHelpers) {
+function parentByHeight(height, includeBlockHelpers, selector) {
   // If height is null or undefined, we default to 1, the first parent.
   if (height == null) height = 1;
 
@@ -17,15 +38,20 @@ Blaze.TemplateInstance.prototype.parent = function parent(height, includeBlockHe
       view = parentView(view, includeBlockHelpers);
     }
     if (!view) return null;
+
     // Body view has template field, but not templateInstance,
     // which more or less signals that we reached the top.
     template = typeof view.templateInstance === 'function' ? view.templateInstance() : null;
+
+    if (!!selector && !!selector(template)) { return template; }
+
     i++;
   }
   return template;
-};
+}
 
 function parentView(view, includeBlockHelpers) {
   if (includeBlockHelpers) return view.originalParentView || view.parentView;
   return view.parentView;
 }
+

--- a/package.js
+++ b/package.js
@@ -1,7 +1,7 @@
 Package.describe({
   name: "aldeed:template-extension",
   summary: "Adds template features currently missing from the templating package",
-  version: "4.0.0",
+  version: "4.0.1",
   git: "https://github.com/aldeed/meteor-template-extension.git"
 });
 

--- a/tests.html
+++ b/tests.html
@@ -56,3 +56,22 @@
 <template name="noop">
   {{> Template.contentBlock}}
 </template>
+
+<template name="templateTier1">
+  {{> templateTier2}}
+  {{> templateTier2}}
+</template>
+
+<template name="templateTier2">
+  <div>
+    What?
+    {{> templateTier3}}
+    {{> templateTier3}}
+  </div>
+</template>
+
+<template name="templateTier3">
+  <div>
+    Hello
+  </div>
+</template>


### PR DESCRIPTION
I ran into the use case of having to traverse up until I am under a certain template and throw error otherwise. To do this elegantly, I added the following feature for the current `parent` function.
